### PR TITLE
`py::arg` and `py::arg_v` member function chaining fixes

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1943,6 +1943,18 @@ struct arg : detail::arg_base {
     template <typename T>
     arg_v operator=(T &&value) const;
 
+    /// Same as `arg_base::noconvert()`, but returns *this as arg&, not arg_base&
+    arg &noconvert(bool flag = true) {
+        arg_base::noconvert(flag);
+        return *this;
+    }
+
+    /// Same as `arg_base::noconvert()`, but returns *this as arg&, not arg_base&
+    arg &none(bool flag = true) {
+        arg_base::none(flag);
+        return *this;
+    }
+
     arg &policies(const from_python_policies &policies) {
         m_policies = policies;
         return *this;
@@ -2010,6 +2022,12 @@ public:
     /// Same as `arg::nonone()`, but returns *this as arg_v&, not arg&
     arg_v &none(bool flag = true) {
         arg::none(flag);
+        return *this;
+    }
+
+    /// Same as `arg::policies()`, but returns *this as arg_v&, not arg&
+    arg_v &policies(const from_python_policies &policies) {
+        arg::policies(policies);
         return *this;
     }
 

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -436,4 +436,50 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
     py::class_<IntOwner>(m, "IntOwner").def_readonly("val", &IntOwner::val);
 
     m.def("call_callback_pass_int_owner_const_ptr", call_callback_pass_int_owner_const_ptr);
+
+    // Ensure chaining py::arg() member functions works.
+    m.def(
+        "arg_chaining_noconvert_policies",
+        [](const std::function<std::string(std::string)> &cb) {
+            return cb("\x80"
+                      "ArgNoconvertPolicies");
+        },
+        py::arg("cb").noconvert().policies(py::return_value_policy_pack({rvpb})),
+        rvpb);
+    m.def(
+        "arg_chaining_none_policies",
+        [](const std::function<std::string(std::string)> &cb) {
+            return cb("\x80"
+                      "ArgNonePolicies");
+        },
+        py::arg("cb").none().policies(py::return_value_policy_pack({rvpb})),
+        rvpb);
+    m.def(
+        "arg_chaining_policies_noconvert",
+        [](const std::function<std::string(std::string)> &cb) {
+            return cb("\x80"
+                      "ArgPoliciesNoconvert");
+        },
+        py::arg("cb").policies(py::return_value_policy_pack({rvpb})).noconvert(),
+        rvpb);
+
+    // Ensure chaining py::arg_v() member functions works.
+    // This does not look very useful, but .policies() chaining was added because
+    // chaining for .noconvert() and .none() existed already.
+    m.def(
+        "arg_v_chaining_noconvert",
+        [](int num) { return num + 10; },
+        (py::arg("num") = 2).noconvert());
+    m.def("arg_v_chaining_none", [](int num) { return num + 20; }, (py::arg("num") = 3).none());
+    m.def(
+        "arg_v_chaining_none_policies",
+        [](const std::function<std::string(std::string)> &cb) {
+            if (cb) {
+                return cb("\x80"
+                          "ArgvNonePolicies");
+            }
+            return std::string("<NONE>");
+        },
+        (py::arg("cb") = py::none()).policies(py::return_value_policy_pack({rvpb})),
+        rvpb);
 }

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -444,7 +444,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             return cb("\x80"
                       "ArgNoconvertPolicies");
         },
-        py::arg("cb").noconvert().policies(py::return_value_policy_pack({rvpb})),
+        py::arg("cb").noconvert().policies(py::return_value_policy_pack(rvpb)),
         rvpb);
     m.def(
         "arg_chaining_none_policies",
@@ -452,7 +452,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             return cb("\x80"
                       "ArgNonePolicies");
         },
-        py::arg("cb").none().policies(py::return_value_policy_pack({rvpb})),
+        py::arg("cb").none().policies(py::return_value_policy_pack(rvpb)),
         rvpb);
     m.def(
         "arg_chaining_policies_noconvert",
@@ -460,7 +460,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             return cb("\x80"
                       "ArgPoliciesNoconvert");
         },
-        py::arg("cb").policies(py::return_value_policy_pack({rvpb})).noconvert(),
+        py::arg("cb").policies(py::return_value_policy_pack(rvpb)).noconvert(),
         rvpb);
 
     // Ensure chaining py::arg_v() member functions works.
@@ -480,6 +480,6 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             }
             return std::string("<NONE>");
         },
-        (py::arg("cb") = py::none()).policies(py::return_value_policy_pack({rvpb})),
+        (py::arg("cb") = py::none()).policies(py::return_value_policy_pack(rvpb)),
         rvpb);
 }

--- a/tests/test_return_value_policy_pack.py
+++ b/tests/test_return_value_policy_pack.py
@@ -337,3 +337,33 @@ def test_call_callback_pass_int_owner():
         return int_owner.val + 40
 
     assert m.call_callback_pass_int_owner_const_ptr(cb) == 543
+
+
+@pytest.mark.parametrize(
+    ("fn", "expected"),
+    [
+        (m.arg_chaining_noconvert_policies, b"\x80ArgNoconvertPolicies"),
+        (m.arg_chaining_none_policies, b"\x80ArgNonePolicies"),
+        (m.arg_chaining_policies_noconvert, b"\x80ArgPoliciesNoconvert"),
+    ],
+)
+def test_arg_chaining(fn, expected):
+    assert fn(lambda arg: arg + b"Extra") == expected + b"Extra"
+
+
+def test_arg_v_chaining_noconvert():
+    assert m.arg_v_chaining_noconvert() == 12
+    assert m.arg_v_chaining_noconvert(4) == 14
+
+
+def test_arg_v_chaining_none():
+    assert m.arg_v_chaining_none() == 23
+    assert m.arg_v_chaining_none(5) == 25
+
+
+def test_arg_v_chaining_none_policies():
+    assert m.arg_v_chaining_none_policies() == b"<NONE>"
+    assert (
+        m.arg_v_chaining_none_policies(lambda arg: arg + b"Extra")
+        == b"\x80ArgvNonePoliciesExtra"
+    )


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Add missing chaining member function for derived types. Add unit tests.

Fixes transferred from cl/627122374 (originally 2024-04-22).

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
